### PR TITLE
Fix setting of the clipping flag by comparing range.min to SCHAR_MIN

### DIFF
--- a/main/src/microphone/microphone.cpp
+++ b/main/src/microphone/microphone.cpp
@@ -116,7 +116,7 @@ microphone_get_samples(amplitude_t * const amplitudePtr, bool * const clipPtr)
         // spin wait until all samples are available
     }
 
-    bool clipping = (_.range.max == SCHAR_MIN) || (_.range.max == SCHAR_MAX);
+    bool clipping = (_.range.min == SCHAR_MIN) || (_.range.max == SCHAR_MAX);
     *clipPtr = clipping;
     amplitude_t amplitude = (int16_t)_.range.max - _.range.min; // top-top [0..255]
 


### PR DESCRIPTION
Previous logic that was responsible for detection of clipping condition had an error where instead of comparing the minimum value against SCHAR_MIN, the maximum value was compared. Because of that clipping was not detected when signal was crossing the lower bound of the range